### PR TITLE
Issue #5: 変換結果の小数第2位での丸めと表示の実装

### DIFF
--- a/fx-converter/src/App.tsx
+++ b/fx-converter/src/App.tsx
@@ -8,6 +8,7 @@ function App() {
   const [from, setFrom] = useState<Currency>('JPY')
   const [to, setTo] = useState<Currency>('KRW')
   const [amountFrom, setAmountFrom] = useState<string>('')
+  const [amountTo, setAmountTo] = useState<string>('')
   const [apiCheck, setApiCheck] = useState<string | null>(null)
   const [apiChecking, setApiChecking] = useState<boolean>(false)
   const currencies: Currency[] = ['JPY', 'KRW', 'SGD']
@@ -32,7 +33,7 @@ function App() {
     return Number.isFinite(n) && n >= 0
   })()
 
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const errors: string[] = []
 
@@ -41,10 +42,30 @@ function App() {
 
     if (errors.length) {
       console.warn('Validation failed:', errors)
+      setAmountTo('')
       return
     }
 
-    console.log('Validation succeeded. Ready to convert.', { from, to, amountFrom })
+    // ② fetchRates(from) でレート取得
+    try {
+      const rates = await fetchRates(from)
+      // ③ to 通貨のレート抽出して amount * rate を計算
+      const rate = rates[to]
+      if (typeof rate !== 'number') {
+        console.warn('Rate for target currency not found', { to, rates })
+        setAmountTo('')
+        return
+      }
+      const n = Number(amountFrom)
+      // ⑤ 小数第2位で丸め（Math.round(n*100)/100）
+      const rounded = Math.round(n * rate * 100) / 100
+      // ④ 結果を「変換後フォーム」に表示
+      setAmountTo(String(rounded))
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn('Failed to fetch rates:', msg)
+      setAmountTo('')
+    }
   }
 
   const runApiCheck = async () => {
@@ -110,7 +131,15 @@ function App() {
             onChange={(e) => setAmountFrom(e.target.value)}
           />
           <div />
-          <input className="converter__amount" type="text" placeholder="" />
+          <input
+            className="converter__amount"
+            name="amount-to"
+            type="text"
+            inputMode="decimal"
+            placeholder=""
+            readOnly
+            value={amountTo}
+          />
 
           {/* Submit row */}
           <button className="converter__submit" type="submit" disabled={!isAmountFromValid}>変換</button>


### PR DESCRIPTION
## 概要
本PRでは、クリック時のフロー **③〜⑤** を実装しました。

---

## 実装内容
### ③
`rates[to]` で対象通貨レートを取得し、変換計算を実行。

### ④
計算結果を変換後フォームに表示（`amountTo` を `readOnly` でバインド）。

### ⑤
`Math.round(n * 100) / 100` により、小数第2位に丸めて表示。

---

## エラーハンドリング
- レートが取得できない、または対象通貨が見つからない場合：  
  → 結果欄（`amountTo`）を空にリセット。

---

## 動作確認
1. 任意の **From / To** を選択。  
2. 金額を入力して「変換」ボタンを押下。  
3. 結果欄に **小数第2位で丸められた値** が表示されることを確認。  

### 例
rate = 13.456
amount = 10
→ 表示 = 134.56