### PR TITLE
3通貨のロケール自動選択＋Intl.NumberFormatでの通貨表示対応

### DIFF
--- a/fx-converter/src/App.tsx
+++ b/fx-converter/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { fetchRates } from './lib/exchange'
+import { formatCurrency } from './lib/format'
 import type { Currency } from './contents/currencies'
 
 import './App.css'
@@ -57,10 +58,9 @@ function App() {
         return
       }
       const n = Number(amountFrom)
-      // ⑤ 小数第2位で丸め（Math.round(n*100)/100）
-      const rounded = Math.round(n * rate * 100) / 100
-      // ④ 結果を「変換後フォーム」に表示
-      setAmountTo(String(rounded))
+      // ④ 結果をロケール付き通貨表現で「変換後フォーム」に表示
+      const converted = n * rate
+      setAmountTo(formatCurrency(converted, to))
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       console.warn('Failed to fetch rates:', msg)

--- a/fx-converter/src/lib/format.ts
+++ b/fx-converter/src/lib/format.ts
@@ -1,0 +1,24 @@
+import type { Currency } from '../contents/currencies'
+
+// Mapping of supported currencies to their appropriate locales
+const CURRENCY_LOCALES: Record<Currency, string> = {
+  JPY: 'ja-JP',
+  KRW: 'ko-KR',
+  SGD: 'en-SG'
+}
+
+/**
+ * Return the best-fit locale for a given currency among supported ones.
+ */
+export function getLocaleForCurrency(currency: Currency): string {
+  return CURRENCY_LOCALES[currency]
+}
+
+/**
+ * Format a number as currency using Intl.NumberFormat and an auto-selected locale.
+ */
+export function formatCurrency(value: number, currency: Currency): string {
+  const locale = getLocaleForCurrency(currency)
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
+}
+


### PR DESCRIPTION
## 背景 / 目的
**Issue要件:**  
`Intl.NumberFormat(locale, { style: 'currency', currency })` を利用し、通貨に応じてロケールを自動選択。  

**対応マッピング:**  
- `KRW` → `ko-KR`  
- `SGD` → `en-SG`  
- `JPY` → `ja-JP`  

---

## 変更内容

### コード
- **`fx-converter/src/lib/format.ts` (line 1)**  
  - `getLocaleForCurrency` と `formatCurrency` を追加

- **`fx-converter/src/App.tsx` (line 3)**  
  - `formatCurrency` を import

- **`fx-converter/src/App.tsx` (line 61)**  
  - 変換結果の表示を `formatCurrency(converted, to)` に変更  
  - 手動の小数2桁丸め (`Math.round`) を撤廃

---

## 動作確認
1. `pnpm dev` または `npm run dev` で起動  
2. 以下の組み合わせで確認  
   - `JPY → KRW`  
   - `JPY → SGD`  
   - `KRW → JPY`  

### 期待結果
| 通貨 | ロケール | 表示例 | 備考 |
|------|-----------|--------|------|
| KRW | ko-KR | ₩13,456 | 桁区切り、小数なし |
| SGD | en-SG | S$13.45 | 小数2桁 |
| JPY | ja-JP | ￥13,456 | 小数なし |

---

## 影響範囲
- 表示専用の変更（**計算ロジック / API呼び出しは不変**）  
- 既存の入力検証・APIチェック機能には影響なし

---

## 補足
- 「常に小数2桁」など別要件がある場合は、  
  `formatCurrency` 内の `Intl.NumberFormat` オプション（例：`maximumFractionDigits`）で調整可能。  
- 対応通貨を追加する場合は、`format.ts` のマッピングに追記することで拡張可能。

---

## 関連
Closes: `#<issue-6>`
