### PR TITLE
API呼び出し中のインジケータと失敗時メッセージを実装 (Issue #7)

### DIFF
--- a/fx-converter/src/App.css
+++ b/fx-converter/src/App.css
@@ -117,6 +117,13 @@
   font-weight: 700;
 }
 
+.converter__error {
+  grid-column: 1 / -1;
+  justify-self: center;
+  color: #d64545;
+  margin-top: -8px;
+}
+
 /* Responsive tweak */
 @media (max-width: 640px) {
   .converter__grid {

--- a/fx-converter/src/App.tsx
+++ b/fx-converter/src/App.tsx
@@ -10,6 +10,8 @@ function App() {
   const [to, setTo] = useState<Currency>('KRW')
   const [amountFrom, setAmountFrom] = useState<string>('')
   const [amountTo, setAmountTo] = useState<string>('')
+  const [converting, setConverting] = useState<boolean>(false)
+  const [convertError, setConvertError] = useState<boolean>(false)
   const [apiCheck, setApiCheck] = useState<string | null>(null)
   const [apiChecking, setApiChecking] = useState<boolean>(false)
   const currencies: Currency[] = ['JPY', 'KRW', 'SGD']
@@ -20,6 +22,7 @@ function App() {
   }, [from, to])
 
   const swap = () => {
+    setConvertError(false)
     setFrom(to)
     setTo(from)
   }
@@ -44,17 +47,21 @@ function App() {
     if (errors.length) {
       console.warn('Validation failed:', errors)
       setAmountTo('')
+      setConvertError(false)
       return
     }
 
     // ② fetchRates(from) でレート取得
     try {
+      setConverting(true)
+      setConvertError(false)
       const rates = await fetchRates(from)
       // ③ to 通貨のレート抽出して amount * rate を計算
       const rate = rates[to]
       if (typeof rate !== 'number') {
         console.warn('Rate for target currency not found', { to, rates })
         setAmountTo('')
+        setConvertError(true)
         return
       }
       const n = Number(amountFrom)
@@ -65,6 +72,9 @@ function App() {
       const msg = err instanceof Error ? err.message : String(err)
       console.warn('Failed to fetch rates:', msg)
       setAmountTo('')
+      setConvertError(true)
+    } finally {
+      setConverting(false)
     }
   }
 
@@ -95,7 +105,7 @@ function App() {
               name="currencies-before"
               aria-label="変換前の通貨"
               value={from}
-              onChange={(e) => setFrom(e.target.value as Currency)}
+              onChange={(e) => { setFrom(e.target.value as Currency); setConvertError(false) }}
             >
               {currencies.map((c) => (
                 <option key={c} value={c}>{c}</option>
@@ -110,7 +120,7 @@ function App() {
               name="currencies-after"
               aria-label="変換後の通貨"
               value={to}
-              onChange={(e) => setTo(e.target.value as Currency)}
+              onChange={(e) => { setTo(e.target.value as Currency); setConvertError(false) }}
             >
               {currencies.map((c) => (
                 <option key={c} value={c}>{c}</option>
@@ -128,7 +138,7 @@ function App() {
             step="any"
             placeholder=""
             value={amountFrom}
-            onChange={(e) => setAmountFrom(e.target.value)}
+            onChange={(e) => { setAmountFrom(e.target.value); setConvertError(false) }}
           />
           <div />
           <input
@@ -142,7 +152,10 @@ function App() {
           />
 
           {/* Submit row */}
-          <button className="converter__submit" type="submit" disabled={!isAmountFromValid}>変換</button>
+          <button className="converter__submit" type="submit" disabled={!isAmountFromValid || converting}>{converting ? '取得中…' : '変換'}</button>
+          {convertError && (
+            <small className="converter__error" role="status" aria-live="polite">レート取得に失敗しました</small>
+          )}
         </div>
       </form>
       <div className="converter__apicheck">


### PR DESCRIPTION
## 概要
変換実行中の重複押下を防止するため、**ボタンを無効化**し、ラベルを「取得中…」に変更しました。  
また、取得失敗時には「レート取得に失敗しました」を小さく表示し、画面再操作時にエラー状態をクリアするようにしました。

---

## 変更点

### 状態管理
- `converting`, `convertError` の2つの状態を追加  

### UI更新
- 変換ボタンの `disabled` 条件を追加  
- 実行中はラベルを「取得中…」に変更  
- 取得失敗時に小さなエラーテキストを表示  

### ハンドリング
- レート未取得 / 例外発生時にエラー表示  
- `finally` ブロックで `converting` を確実に解除  

### スタイル
- エラーテキスト用に簡易スタイル（小さめ文字・赤系カラー）を追加  

---

## 動作確認

1. 金額を入力し「変換」ボタンを押下  
　→ ボタンが「取得中…」となり無効化される  
2. APIキーやURLを無効にする、または通信を遮断してエラーを発生させる  
　→ 「レート取得に失敗しました」と表示される  
3. 入力変更・通貨変更・スワップ・再送信を行う  
　→ エラーテキストが消え、再試行可能になる  
4. 通信成功時  
　→ 結果が正常に表示され、ボタン状態が元に戻る  

---

## 受け入れ条件
- 通信中の多重押下が防止されること  
- 失敗時もリロード不要で再試行できること  

---

## 補足
さらに厳密にする場合は、変換中に **通貨セレクトやスワップ操作も無効化** できます。  
必要に応じて今後のPRで対応可能です。
